### PR TITLE
NCSD-544: container access

### DIFF
--- a/Resources/template.json
+++ b/Resources/template.json
@@ -64,7 +64,7 @@
             "value": "tribalexporter"
           },
           "publicAccess": {
-            "value": "Container"
+            "value": "None"
           }
         }
       }


### PR DESCRIPTION
Changed tribalexporter container from public read access to no public access (access requires SAS tokens)