### PR TITLE
Added Export Venues

### DIFF
--- a/src/Dfc.CourseDirectory.Models/Interfaces/Venues/IVenue.cs
+++ b/src/Dfc.CourseDirectory.Models/Interfaces/Venues/IVenue.cs
@@ -19,10 +19,10 @@ namespace Dfc.CourseDirectory.Models.Interfaces.Venues
         string Town { get; }
         string County { get; }
         string PostCode { get; }
-        decimal Latitude { get; set; }
-        decimal Longitude { get; set; }
+        decimal? Latitude { get; set; }
+        decimal? Longitude { get; set; }
         VenueStatus Status { get; set; }
-        DateTime DateAdded { get; }
+        DateTime? DateAdded { get; }
         DateTime DateUpdated { get; }
         string UpdatedBy { get; }
 

--- a/src/Dfc.CourseDirectory.Models/Interfaces/Venues/IVenue.cs
+++ b/src/Dfc.CourseDirectory.Models/Interfaces/Venues/IVenue.cs
@@ -29,7 +29,7 @@ namespace Dfc.CourseDirectory.Models.Interfaces.Venues
         string Telephone { get; set; }
         string Email { get; set; }
         string Website { get; set; }
-        string id { get; set; }
+        string ID { get; set; }
     }
 }
 

--- a/src/Dfc.CourseDirectory.Models/Interfaces/Venues/IVenue.cs
+++ b/src/Dfc.CourseDirectory.Models/Interfaces/Venues/IVenue.cs
@@ -8,7 +8,6 @@ namespace Dfc.CourseDirectory.Models.Interfaces.Venues
 {
     public interface IVenue
     {
-        string ID { get; }
         int UKPRN { get; set; }
         int ProviderID { get; }
         int VenueID { get; }
@@ -19,10 +18,9 @@ namespace Dfc.CourseDirectory.Models.Interfaces.Venues
         string Town { get; }
         string County { get; }
         string PostCode { get; }
-        decimal? Latitude { get; set; }
-        decimal? Longitude { get; set; }
+        double? Latitude { get; set; }
+        double? Longitude { get; set; }
         VenueStatus Status { get; set; }
-        DateTime? DateAdded { get; }
         DateTime DateUpdated { get; }
         string UpdatedBy { get; }
 
@@ -31,6 +29,7 @@ namespace Dfc.CourseDirectory.Models.Interfaces.Venues
         string Telephone { get; set; }
         string Email { get; set; }
         string Website { get; set; }
+        string id { get; set; }
     }
 }
 

--- a/src/Dfc.CourseDirectory.Models/Models/Venues/Venue.cs
+++ b/src/Dfc.CourseDirectory.Models/Models/Venues/Venue.cs
@@ -21,38 +21,32 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
 
     public class Venue : ValueObject<Venue>, IVenue
     {
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string ID { get; }
         public int UKPRN { get; set; }
         [JsonProperty("PROVIDER_ID", Required = Required.AllowNull)]
-        public int ProviderID { get; }
+        public int ProviderID { get; set; }
         [JsonProperty("VENUE_ID", Required = Required.AllowNull)]
-        public int VenueID { get; }
+        public int VenueID { get; set; }
         [JsonProperty("VENUE_NAME")]
-        public string VenueName { get; }
+        public string VenueName { get; set; }
         [JsonProperty("PROV_VENUE_ID", Required = Required.AllowNull)]
-        public string ProvVenueID { get; }
+        public string ProvVenueID { get; set; }
         [JsonProperty("ADDRESS_1")]
-        public string Address1 { get; }
+        public string Address1 { get; set; }
         [JsonProperty("ADDRESS_2")]
-        public string Address2 { get; }
-        [JsonProperty("ADDRESS_3" , Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-        public string Address3 { get; }
+        public string Address2 { get; set; }
         [JsonProperty("TOWN")]
-        public string Town { get; }
+        public string Town { get; set; }
         [JsonProperty("COUNTY")]
-        public string County { get; }
+        public string County { get; set; }
         [JsonProperty("POSTCODE")]
-        public string PostCode { get; }
+        public string PostCode { get; set; }
         [JsonProperty("LATITUDE")]
-        public decimal? Latitude { get; set; }
+        public double? Latitude { get; set; }
         [JsonProperty("LONGITUDE")]
-        public decimal? Longitude { get; set; }
+        public double? Longitude { get; set; }
         public VenueStatus Status { get; set; }
-        [JsonProperty("DateAdded", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-        public DateTime? DateAdded { get; }
-        public DateTime DateUpdated { get; }
-        public string UpdatedBy { get; }
+        public DateTime DateUpdated { get; set; }
+        public string UpdatedBy { get; set; }
 
         // Apprenticeship related
         public string PHONE { get; set; }
@@ -64,22 +58,27 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
         public string Telephone { get { return PHONE; } set { PHONE = value; } }
         public string Email { get { return EMAIL; } set { EMAIL = value; } }
         public string Website { get { return WEBSITE; } set { WEBSITE = value; } }
+        [JsonProperty("id")]
+        public string id { get; set; }
+        public string CreatedBy { get; set; }
+        public DateTime CreatedDate { get; set; }
+
+        public Venue()
+        {
+        }
 
         public Venue(
-            string id,
             int ukPrn,
             string venueName,
             string address1,
             string address2,
-            string address3,
             string town,
             string county,
             string postcode,
-            decimal? latitude,
-            decimal? longitude,
+            double? latitude,
+            double? longitude,
             VenueStatus status,
             string updatedBy,
-            DateTime dateAdded,
             DateTime dateUpdated)
         {
             //Throw.IfNullOrWhiteSpace(id, nameof(id));
@@ -89,12 +88,10 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             Throw.IfNullOrWhiteSpace(town, nameof(town));
             Throw.IfNullOrWhiteSpace(postcode, nameof(postcode));
 
-            ID = id;
             UKPRN = ukPrn;
             VenueName = venueName;
             Address1 = address1;
             Address2 = address2;
-            Address3 = address3;
             Town = town;
             County = county;
             PostCode = postcode;
@@ -102,13 +99,12 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             Longitude = longitude;
             Status = status;
             UpdatedBy = updatedBy;
-            DateAdded = dateAdded;
             DateUpdated = dateUpdated;
 
         }
 
 
-        [JsonConstructor]
+        //[JsonConstructor]
         public Venue(
             string id,
             int ukPrn,
@@ -122,8 +118,8 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             string town,
             string county,
             string postcode,
-            decimal? latitude,
-            decimal? longitude,
+            double? latitude,
+            double? longitude,
             VenueStatus status,
             string updatedBy,
             DateTime dateAdded,
@@ -139,8 +135,6 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             //Throw.IfNullOrWhiteSpace(postcode, nameof(postcode));
             //Throw.IfNullOrWhiteSpace(updatedBy, nameof(updatedBy));
 
-
-            ID = id;
             UKPRN = ukPrn;
             ProviderID = providerID;
             VenueID = venueID;
@@ -148,7 +142,6 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             ProvVenueID = provVenueID;
             Address1 = address1;
             Address2 = address2;
-            Address3 = address3;
             Town = town;
             County = county;
             PostCode = postcode;
@@ -156,14 +149,12 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             Longitude = longitude;
             Status = status;
             UpdatedBy = updatedBy;
-            DateAdded = dateAdded;
             DateUpdated = dateUpdated;
 
         }
 
 
         public Venue(
-            string id,
             int ukPrn,
             string venueName,
             string address1,
@@ -172,14 +163,13 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             string town,
             string county,
             string postcode,
-            decimal ?latitude,
-            decimal? longitude,
+            double? latitude,
+            double? longitude,
             VenueStatus status,
             string updatedBy,
             DateTime dateUpdated
             )
         {
-            Throw.IfNullOrWhiteSpace(id, nameof(id));
             Throw.IfLessThan(0, ukPrn, nameof(ukPrn));
             //Throw.IfLessThan(0, providerID, nameof(providerID));
             //Throw.IfLessThan(0, venueID, nameof(venueID));
@@ -192,13 +182,10 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             //Throw.IfNullOrWhiteSpace(postcode, nameof(postcode));
             //Throw.IfNullOrWhiteSpace(updatedBy, nameof(updatedBy));
 
-
-            ID = id;
             UKPRN = ukPrn;
             VenueName = venueName;
             Address1 = address1;
             Address2 = address2;
-            Address3 = address3;
             Town = town;
             County = county;
             PostCode = postcode;
@@ -209,51 +196,8 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             DateUpdated = dateUpdated;
         }
 
-
-        public Venue(
-    string id,
-    int ukPrn,
-    string venueName,
-    string address1,
-    string address2,
-    string address3,
-    string town,
-    string county,
-    string postcode,
-    double? latitude,
-    double? longitude,
-    VenueStatus status,
-    string updatedBy,
-    DateTime dateUpdated,
-    int venueId,
-    int providerId,
-    string providerOwnRef)
-        {
-            Throw.IfNullOrWhiteSpace(id, nameof(id));
-            Throw.IfLessThan(0, ukPrn, nameof(ukPrn));
-            ID = id;
-            UKPRN = ukPrn;
-            VenueName = venueName;
-            Address1 = address1;
-            Address2 = address2;
-            Address3 = address3;
-            Town = town;
-            County = county;
-            PostCode = postcode;
-            Latitude = latitude.HasValue ?  Convert.ToDecimal(latitude.Value) : default(decimal?);
-            Longitude = longitude.HasValue ? Convert.ToDecimal(longitude.Value) : default(decimal?); ;
-            Status = status;
-            UpdatedBy = updatedBy;
-            DateUpdated = dateUpdated;
-            VenueID = venueId;
-            ProviderID = providerId;
-            ProvVenueID = providerOwnRef;
-        }
-
-
         protected override IEnumerable<object> GetEqualityComponents()
         {
-            yield return ID;
             yield return UKPRN;
             yield return ProviderID;
             yield return VenueID;
@@ -261,7 +205,6 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             yield return ProvVenueID;
             yield return Address1;
             yield return Address2;
-            yield return Address3;
             yield return Town;
             yield return County;
             yield return PostCode;
@@ -269,7 +212,6 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             yield return Longitude;
             yield return Status;
             yield return UpdatedBy;
-            yield return DateAdded;
             yield return DateUpdated;
         }
     }

--- a/src/Dfc.CourseDirectory.Models/Models/Venues/Venue.cs
+++ b/src/Dfc.CourseDirectory.Models/Models/Venues/Venue.cs
@@ -13,8 +13,9 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
     {
         Undefined = 0,
         Live = 1,
-        Deleted = 2,
-        Pending = 3,
+        Pending = 2,
+        Archived = 4,
+        Deleted = 8,
         Uknown = 99
     }
 
@@ -24,21 +25,18 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
         public string ID { get; }
         public int UKPRN { get; set; }
         [JsonProperty("PROVIDER_ID", Required = Required.AllowNull)]
-        [JsonIgnore]
         public int ProviderID { get; }
         [JsonProperty("VENUE_ID", Required = Required.AllowNull)]
-        [JsonIgnore]
         public int VenueID { get; }
         [JsonProperty("VENUE_NAME")]
         public string VenueName { get; }
         [JsonProperty("PROV_VENUE_ID", Required = Required.AllowNull)]
-        [JsonIgnore]
         public string ProvVenueID { get; }
         [JsonProperty("ADDRESS_1")]
         public string Address1 { get; }
         [JsonProperty("ADDRESS_2")]
         public string Address2 { get; }
-        [JsonProperty("ADDRESS_3")]
+        [JsonProperty("ADDRESS_3" , Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
         public string Address3 { get; }
         [JsonProperty("TOWN")]
         public string Town { get; }
@@ -47,11 +45,12 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
         [JsonProperty("POSTCODE")]
         public string PostCode { get; }
         [JsonProperty("LATITUDE")]
-        public decimal Latitude { get; set; }
+        public decimal? Latitude { get; set; }
         [JsonProperty("LONGITUDE")]
-        public decimal Longitude { get; set; }
+        public decimal? Longitude { get; set; }
         public VenueStatus Status { get; set; }
-        public DateTime DateAdded { get; }
+        [JsonProperty("DateAdded", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+        public DateTime? DateAdded { get; }
         public DateTime DateUpdated { get; }
         public string UpdatedBy { get; }
 
@@ -76,8 +75,8 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             string town,
             string county,
             string postcode,
-            decimal latitude,
-            decimal longitude,
+            decimal? latitude,
+            decimal? longitude,
             VenueStatus status,
             string updatedBy,
             DateTime dateAdded,
@@ -123,8 +122,8 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             string town,
             string county,
             string postcode,
-            decimal latitude,
-            decimal longitude,
+            decimal? latitude,
+            decimal? longitude,
             VenueStatus status,
             string updatedBy,
             DateTime dateAdded,
@@ -173,11 +172,12 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             string town,
             string county,
             string postcode,
-            decimal latitude,
-            decimal longitude,
+            decimal ?latitude,
+            decimal? longitude,
             VenueStatus status,
             string updatedBy,
-            DateTime dateUpdated)
+            DateTime dateUpdated
+            )
         {
             Throw.IfNullOrWhiteSpace(id, nameof(id));
             Throw.IfLessThan(0, ukPrn, nameof(ukPrn));
@@ -207,7 +207,47 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
             Status = status;
             UpdatedBy = updatedBy;
             DateUpdated = dateUpdated;
+        }
 
+
+        public Venue(
+    string id,
+    int ukPrn,
+    string venueName,
+    string address1,
+    string address2,
+    string address3,
+    string town,
+    string county,
+    string postcode,
+    double? latitude,
+    double? longitude,
+    VenueStatus status,
+    string updatedBy,
+    DateTime dateUpdated,
+    int venueId,
+    int providerId,
+    string providerOwnRef)
+        {
+            Throw.IfNullOrWhiteSpace(id, nameof(id));
+            Throw.IfLessThan(0, ukPrn, nameof(ukPrn));
+            ID = id;
+            UKPRN = ukPrn;
+            VenueName = venueName;
+            Address1 = address1;
+            Address2 = address2;
+            Address3 = address3;
+            Town = town;
+            County = county;
+            PostCode = postcode;
+            Latitude = latitude.HasValue ?  Convert.ToDecimal(latitude.Value) : default(decimal?);
+            Longitude = longitude.HasValue ? Convert.ToDecimal(longitude.Value) : default(decimal?); ;
+            Status = status;
+            UpdatedBy = updatedBy;
+            DateUpdated = dateUpdated;
+            VenueID = venueId;
+            ProviderID = providerId;
+            ProvVenueID = providerOwnRef;
         }
 
 

--- a/src/Dfc.CourseDirectory.Models/Models/Venues/Venue.cs
+++ b/src/Dfc.CourseDirectory.Models/Models/Venues/Venue.cs
@@ -59,7 +59,7 @@ namespace Dfc.CourseDirectory.Models.Models.Venues
         public string Email { get { return EMAIL; } set { EMAIL = value; } }
         public string Website { get { return WEBSITE; } set { WEBSITE = value; } }
         [JsonProperty("id")]
-        public string id { get; set; }
+        public string ID { get; set; }
         public string CreatedBy { get; set; }
         public DateTime CreatedDate { get; set; }
 

--- a/src/Dfc.CourseDirectory.Services/VenueService/VenueService.cs
+++ b/src/Dfc.CourseDirectory.Services/VenueService/VenueService.cs
@@ -300,7 +300,7 @@ namespace Dfc.CourseDirectory.Services.VenueService
 
                     if (!String.IsNullOrEmpty(criteria.NewAddressId))
                     {
-                        var newVenueIndex = venues.FindIndex(x => x.ID == criteria.NewAddressId);
+                        var newVenueIndex = 0;  // venues.FindIndex(x => x.ID == criteria.NewAddressId);
                         var newVenueItem = venues[newVenueIndex];
 
                         venues.RemoveAt(newVenueIndex);

--- a/src/Dfc.ProviderPortal.ApprenticeshipMigration/ApprenticeshipMigration.cs
+++ b/src/Dfc.ProviderPortal.ApprenticeshipMigration/ApprenticeshipMigration.cs
@@ -474,8 +474,8 @@ namespace Dfc.ProviderPortal.ApprenticeshipMigration
                                                             else
                                                             {
                                                                 apprenticeshipLocation.LocationId = venue.LocationId ?? location.LocationId;
-                                                                apprenticeshipLocation.LocationGuidId =
-                                                                    new Guid(venue.ID);
+                                                                //apprenticeshipLocation.LocationGuidId =
+                                                                //    new Guid(venue.ID);
                                                                 apprenticeshipLocation.Address = new Address()
                                                                 {
                                                                     Address1 = venue.Address1,
@@ -576,7 +576,7 @@ namespace Dfc.ProviderPortal.ApprenticeshipMigration
                                                         {
                                                             var venueID = Guid.NewGuid();
                                                             // There is no such Venue - Add it
-                                                            var addVenue = new Venue(venueID.ToString(),
+                                                            var addVenue = new Venue(
                                                                 location.ProviderUKPRN,
                                                                 location.LocationName,
                                                                 location.AddressLine1,
@@ -585,8 +585,8 @@ namespace Dfc.ProviderPortal.ApprenticeshipMigration
                                                                 location.Town,
                                                                 location.County,
                                                                 location.Postcode,
-                                                                location.Latitude,
-                                                                location.Longitude,
+                                                                Convert.ToDouble(location.Latitude),
+                                                                Decimal.ToDouble(location.Longitude),
                                                                 VenueStatus.Live,
                                                                 "DFC – Apprenticeship Migration Tool",
                                                                 DateTime.Now);

--- a/src/Dfc.ProviderPortal.ApprenticeshipMigration/ApprenticeshipMigration.cs
+++ b/src/Dfc.ProviderPortal.ApprenticeshipMigration/ApprenticeshipMigration.cs
@@ -482,12 +482,12 @@ namespace Dfc.ProviderPortal.ApprenticeshipMigration
                                                                     Address2 = venue.Address2,
                                                                     County = venue.County,
                                                                     Email = venue.Email,
-                                                                    Latitude = double.Parse(
-                                                                        venue.Latitude.ToString(CultureInfo
-                                                                            .InvariantCulture)),
-                                                                    Longitude = double.Parse(
-                                                                        venue.Longitude.ToString(CultureInfo
-                                                                            .InvariantCulture)),
+                                                                    Latitude = venue.Latitude.HasValue ? double.Parse(
+                                                                        venue.Latitude.Value.ToString(CultureInfo
+                                                                            .InvariantCulture)) : default(double?),
+                                                                    Longitude = venue.Longitude.HasValue ? double.Parse(
+                                                                        venue.Longitude.Value.ToString(CultureInfo
+                                                                            .InvariantCulture)) : default(double?),
                                                                     Phone = venue.PHONE,
                                                                     Postcode = venue.PostCode,
                                                                     Town = venue.Town,

--- a/src/Dfc.ProviderPortal.TribalExporter/Dfc.ProviderPortal.TribalExporter.csproj
+++ b/src/Dfc.ProviderPortal.TribalExporter/Dfc.ProviderPortal.TribalExporter.csproj
@@ -7,6 +7,7 @@
     <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="13.0.0" />
     <PackageReference Include="Dfc.ProviderPortal.Packages" Version="0.1.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.3" />

--- a/src/Dfc.ProviderPortal.TribalExporter/Functions/VenueMigrator.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Functions/VenueMigrator.cs
@@ -115,11 +115,11 @@ namespace Dfc.ProviderPortal.TribalExporter.Functions
                                     var cosmosVenue = await venueCollectionService.GetDocumentID(item.VenueId);
                                     if (cosmosVenue != null)
                                     {
-                                        var s = UriFactory.CreateDocumentUri(databaseId, venuesCollectionId, cosmosVenue.id.ToString());
+                                        var s = UriFactory.CreateDocumentUri(databaseId, venuesCollectionId, cosmosVenue.ID.ToString());
                                         Uri collectionUri = UriFactory.CreateDocumentCollectionUri(databaseId, venuesCollectionId);
                                         var editedVenue = new Dfc.CourseDirectory.Models.Models.Venues.Venue()
                                         {
-                                            id = cosmosVenue.id,
+                                            ID = cosmosVenue.ID,
                                             UKPRN = item.UKPRN,
                                             VenueName = item.VenueName,
                                             Address1 = item.Address.Address1,

--- a/src/Dfc.ProviderPortal.TribalExporter/Functions/VenueMigrator.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Functions/VenueMigrator.cs
@@ -22,6 +22,17 @@ namespace Dfc.ProviderPortal.TribalExporter.Functions
 {
     public static class VenueMigrator
     {
+        /// <summary>
+        /// This function app migrates venues from a 
+        /// </summary>
+        /// <param name="req"></param>
+        /// <param name="log"></param>
+        /// <param name="configuration"></param>
+        /// <param name="venueCollectionService"></param>
+        /// <param name="providerCollectionService"></param>
+        /// <param name="cosmosDbHelper"></param>
+        /// <param name="blobhelper"></param>
+        /// <returns></returns>
         [FunctionName(nameof(VenueMigrator))]
         public static async Task Run(
                     [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] Microsoft.AspNetCore.Http.HttpRequest req,

--- a/src/Dfc.ProviderPortal.TribalExporter/Functions/VenueMigrator.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Functions/VenueMigrator.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Dfc.ProviderPortal.Packages.AzureFunctions.DependencyInjection;
+using Dfc.ProviderPortal.TribalExporter.Interfaces;
+using Dfc.ProviderPortal.TribalExporter.Models.Tribal;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System.Linq;
+using System.Text;
+using CsvHelper;
+using System.Globalization;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace Dfc.ProviderPortal.TribalExporter.Functions
+{
+    public static class VenueMigrator
+    {
+        [FunctionName(nameof(VenueMigrator))]
+        public static async Task Run(
+                    [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] Microsoft.AspNetCore.Http.HttpRequest req,
+                    ILogger log,
+                    [Inject] IConfigurationRoot configuration,
+                    [Inject] IVenueCollectionService venueCollectionService,
+                    [Inject] IProviderCollectionService providerCollectionService,
+                    [Inject] ICosmosDbHelper cosmosDbHelper,
+                    [Inject] IBlobStorageHelper blobhelper
+                    )
+        {
+            var venuesCollectionId = configuration["CosmosDbCollectionSettings:VenuesCollectionId"];
+            var connectionString = configuration.GetConnectionString("DefaultConnection");
+            var blobContainer = blobhelper.GetBlobContainer(configuration["BlobStorageSettings:Container"]);
+            var whiteListProviders = await GetProviderWhiteList();
+            var result = new List<ResultMessage>();
+            var venueExportFileName = $"VenueExport-{DateTime.Now.ToString("dd-MM-yy HHmm")}";
+            const string WHITE_LIST_FILE = "ProviderWhiteList.txt";
+            var ukprnCache = new List<int>();
+
+            using (var sqlConnection = new SqlConnection(connectionString))
+            {
+                using (var command = sqlConnection.CreateCommand())
+                {
+                    command.CommandType = CommandType.Text;
+                    command.CommandText = @"SELECT 
+	                                              Ven.[VenueId],
+                                                  Ven.[ProviderId],
+                                                  Ven.[ProviderOwnVenueRef],
+                                                  Ven.[VenueName],
+                                                  Ven.[Email],
+                                                  Ven.[Website],
+                                                  Ven.[Fax],
+                                                  Ven.[Facilities],
+                                                  Ven.[RecordStatusId],
+                                                  Ven.[CreatedByUserId],
+                                                  Ven.[CreatedDateTimeUtc],
+                                                  Ven.[ModifiedByUserId],
+                                                  Ven.[ModifiedDateTimeUtc],
+                                                  Ven.[AddressId],
+                                                  Ven.[Telephone],
+                                                  Ven.[BulkUploadVenueId],
+                                                  Ven.[CosmosId],
+                                                  Ven.[AddedByApplicationId],
+	                                              Ad.AddressLine1,
+	                                              ad.AddressLine2,
+                                                  ad.Town,
+	                                              ad.County,
+	                                              ad.Postcode,
+                                                  ad.[Latitude],
+                                                  ad.[Longitude],
+	                                              pr.ModifiedDateTimeUtc,
+	                                              pr.ModifiedDateTimeUtc,
+                                                  pr.Ukprn
+                                            FROM Venue Ven
+                                            INNER JOIN [Address] Ad on Ad.AddressId = Ven.AddressId
+                                            INNER JOIN [Provider] pr on pr.ProviderId = ven.ProviderId";
+
+                    try
+                    {
+                        //Open connection.
+                        sqlConnection.Open();
+
+                        using (SqlDataReader dataReader = command.ExecuteReader())
+                        {
+                            while (dataReader.Read())
+                            {
+                                //Read venue
+                                var item = Venue.FromDataReader(dataReader);
+
+                                if (await Validate(item))
+                                {
+                                    var newVenue = new Dfc.CourseDirectory.Models.Models.Venues.Venue(Guid.NewGuid().ToString(),
+                                                                                                      item.UKPRN,
+                                                                                                      item.VenueName,
+                                                                                                      item.Address.Address1,
+                                                                                                      item.Address.Address2,
+                                                                                                      null,
+                                                                                                      item.Address.Town,
+                                                                                                      item.Address.County,
+                                                                                                      item.Address.Postcode,
+                                                                                                      item.Address.Latitude,
+                                                                                                      item.Address.Longitude,
+                                                                                                      MapVenueStatus(item.RecordStatusId),
+                                                                                                      item.CreatedByUserId,
+                                                                                                      item.CreatedDateTimeUtc,
+                                                                                                      item.VenueId,
+                                                                                                      item.ProviderId,
+                                                                                                      item.ProviderOwnVenueRef
+                                                                                                      );
+                                    await cosmosDbHelper.CreateDocumentAsync(cosmosDbHelper.GetClient(), venuesCollectionId, newVenue);
+
+                                    //Log that successfully inserted venue
+                                    AddResultMessage(item.VenueId, "Success");
+                                }
+
+                            }
+                            // Close the SqlDataReader.
+                            dataReader.Close();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        log.LogError(ex.Message);
+                    }
+                }
+                var resultsObjBytes = GetResultAsByteArray(result);
+                await WriteResultsToBlobStorage(resultsObjBytes);
+            }
+
+            CourseDirectory.Models.Models.Venues.VenueStatus MapVenueStatus(int recordStatus)
+            {
+                switch (recordStatus)
+                {
+                    case 1: return CourseDirectory.Models.Models.Venues.VenueStatus.Pending;
+                    case 2: return CourseDirectory.Models.Models.Venues.VenueStatus.Live;
+                    case 3: return CourseDirectory.Models.Models.Venues.VenueStatus.Archived;
+                    case 4: return CourseDirectory.Models.Models.Venues.VenueStatus.Deleted;
+                    default: throw new Exception("$Unable to map recordStatus to VenueStatus");
+                }
+            }
+            
+            byte[] GetResultAsByteArray(IList<ResultMessage> ob)
+            {
+                using (var memoryStream = new System.IO.MemoryStream())
+                {
+                    using (var streamWriter = new System.IO.StreamWriter(memoryStream))
+                    using (var csvWriter = new CsvWriter(streamWriter, CultureInfo.InvariantCulture))
+                    {
+                        csvWriter.WriteRecords<ResultMessage>(ob);
+                    } 
+                    return memoryStream.ToArray();
+                }
+            }
+
+            async Task WriteResultsToBlobStorage(byte[] data)
+            {
+                await blobhelper.UploadFile(blobContainer, venueExportFileName, data);
+            }
+
+            async Task<IList<int>> GetProviderWhiteList()
+            {
+                var list = new List<int>();
+                var whiteList = await blobhelper.ReadFileAsync(blobContainer, WHITE_LIST_FILE);
+                if (!string.IsNullOrEmpty(whiteList))
+                {
+                    var lines = whiteList.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+                    foreach (string line in lines)
+                    {
+                        if (int.TryParse(line, out int id))
+                        {
+                            list.Add(id);
+                        }
+                    }
+                }
+                return list;
+            }
+
+            void AddResultMessage(int venueId, string status, string message="")
+            {
+                var validateResult = new ResultMessage() {VenueId=venueId, Status = status, Message= message};
+                result.Add(validateResult);
+            }
+
+            async Task<bool> Validate(Venue item)
+            {
+                //add prn to cache
+                if (!ukprnCache.Contains(item.UKPRN))
+                {
+                    ukprnCache.Add(item.UKPRN);
+                }
+
+                //venue exists
+                var cosmosVenue = await venueCollectionService.VenueExists(item.VenueId);
+                if (cosmosVenue)
+                {
+                    AddResultMessage(item.VenueId, "Failed" ,"Venue already exists in Cosmos");
+                    return false;
+                }
+
+                //check to see if a record is already held for ukprn
+                if (!ukprnCache.Contains(item.UKPRN))
+                {
+                    var cosmosProvider = await providerCollectionService.ProviderExists(item.UKPRN);
+                    if (!cosmosProvider)
+                    {
+                        AddResultMessage(item.VenueId,"Failed", "Unknown UKPRN");
+                        return false;
+                    }
+                }
+
+                //are providers on list of whitelisted providers file
+                if (!whiteListProviders.Any(x => x == item.UKPRN))
+                {
+                    AddResultMessage(item.VenueId, "Failed", $"Provider {item.ProviderId} not on whitelist, ukprn {item.UKPRN}");
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+}
+
+[Serializable()]
+public class ResultMessage
+{
+    public int VenueId { get; set; }
+    public string Status { get; set; }
+    public string Message { get; set; }
+}

--- a/src/Dfc.ProviderPortal.TribalExporter/Helpers/BlobStorageHelper.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Helpers/BlobStorageHelper.cs
@@ -10,6 +10,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Dfc.ProviderPortal.TribalExporter.Helpers
 {
@@ -22,6 +23,15 @@ namespace Dfc.ProviderPortal.TribalExporter.Helpers
             Throw.IfNull(settings, nameof(settings));
 
             _blobStorageSettings = settings.Value;
+        }
+
+        public async Task UploadFile(CloudBlobContainer container, string fileName, byte[] data)
+        {
+            var blob = container.GetBlockBlobReference(fileName);
+            using (var stream = new MemoryStream(data))
+            {
+                await blob.UploadFromStreamAsync(stream);
+            }
         }
 
         public CloudBlobContainer GetBlobContainer(string containerName)

--- a/src/Dfc.ProviderPortal.TribalExporter/Interfaces/IBlobStorageHelper.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Interfaces/IBlobStorageHelper.cs
@@ -7,5 +7,6 @@ namespace Dfc.ProviderPortal.TribalExporter.Interfaces
     {
         CloudBlobContainer GetBlobContainer(string containerName);
         Task<string> ReadFileAsync(CloudBlobContainer container, string fileName);
+        Task UploadFile(CloudBlobContainer container, string fileName, byte[] data);
     }
 }

--- a/src/Dfc.ProviderPortal.TribalExporter/Interfaces/IProviderCollectionService.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Interfaces/IProviderCollectionService.cs
@@ -6,5 +6,6 @@ namespace Dfc.ProviderPortal.TribalExporter.Interfaces
     public interface IProviderCollectionService
     {
         Task<string> GetAllAsJsonAsync(IEnumerable<int> ukprns);
+        Task<bool> ProviderExists(int ukprn);
     }
 }

--- a/src/Dfc.ProviderPortal.TribalExporter/Interfaces/IVenueCollectionService.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Interfaces/IVenueCollectionService.cs
@@ -7,5 +7,6 @@ namespace Dfc.ProviderPortal.TribalExporter.Interfaces
     {
         Task<string> GetAllVenuesAsJsonForUkprnAsync(int ukprn);
         Task<bool> HasBeenAnUpdatedSinceAsync(int ukprn, DateTime date);
+        Task<bool> VenueExists(int venueId);
     }
 }

--- a/src/Dfc.ProviderPortal.TribalExporter/Interfaces/IVenueCollectionService.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Interfaces/IVenueCollectionService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Dfc.CourseDirectory.Models.Models.Venues;
+using System;
 using System.Threading.Tasks;
 
 namespace Dfc.ProviderPortal.TribalExporter.Interfaces
@@ -7,6 +8,6 @@ namespace Dfc.ProviderPortal.TribalExporter.Interfaces
     {
         Task<string> GetAllVenuesAsJsonForUkprnAsync(int ukprn);
         Task<bool> HasBeenAnUpdatedSinceAsync(int ukprn, DateTime date);
-        Task<bool> VenueExists(int venueId);
+        Task<Venue> GetDocumentID(int venueId);
     }
 }

--- a/src/Dfc.ProviderPortal.TribalExporter/Models/Tribal/Venue.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Models/Tribal/Venue.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Dfc.CourseDirectory.Models.Enums;
+using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Text;
@@ -7,6 +8,7 @@ namespace Dfc.ProviderPortal.TribalExporter.Models.Tribal
 {
     public class Venue
     {
+        public string ID { get; set; }
         public int UKPRN { get; set; }
         public int VenueId { get; set; }
         public int ProviderId { get; set; }
@@ -16,7 +18,7 @@ namespace Dfc.ProviderPortal.TribalExporter.Models.Tribal
         public string Website { get; set; }
         public string Fax { get; set; }
         public string Facilities { get; set; }
-        public int RecordStatusId { get; set; }
+        public TribalRecordStatus RecordStatusId { get; set; }
         public string CreatedByUserId { get; set; }
         public DateTime CreatedDateTimeUtc { get; set; }
         public string ModifiedByUserId { get; set; }
@@ -41,7 +43,7 @@ namespace Dfc.ProviderPortal.TribalExporter.Models.Tribal
             item.Website = reader["Website"] as string;
             item.Fax = reader["Fax"] as string;
             item.Facilities = reader["Facilities"] as string;
-            item.RecordStatusId = (int) reader["RecordStatusId"];
+            item.RecordStatusId = (TribalRecordStatus) Enum.Parse(typeof(TribalRecordStatus), reader["RecordStatusId"].ToString());
             item.CreatedByUserId = reader["CreatedByUserId"] as string;
             item.CreatedDateTimeUtc = (DateTime)reader["CreatedDateTimeUtc"];
             item.ModifiedByUserId = reader["ModifiedByUserId"] as string;

--- a/src/Dfc.ProviderPortal.TribalExporter/Models/Tribal/Venue.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Models/Tribal/Venue.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Text;
+
+namespace Dfc.ProviderPortal.TribalExporter.Models.Tribal
+{
+    public class Venue
+    {
+        public int UKPRN { get; set; }
+        public int VenueId { get; set; }
+        public int ProviderId { get; set; }
+        public string ProviderOwnVenueRef { get; set; }
+        public string VenueName { get; set; }
+        public string Email { get; set; }
+        public string Website { get; set; }
+        public string Fax { get; set; }
+        public string Facilities { get; set; }
+        public int RecordStatusId { get; set; }
+        public string CreatedByUserId { get; set; }
+        public DateTime CreatedDateTimeUtc { get; set; }
+        public string ModifiedByUserId { get; set; }
+        public DateTime? ModifiedDateTimeUtc { get; set; }
+        public int AddressId { get; set; }
+        public string Telephone { get; set; }
+        public string BulkUploadVenueId { get; set; }
+        public string CosmosId { get; set; }
+        public int? AddedByApplicationId { get; set; }
+        public Address Address { get; set; }
+ 
+
+
+        public static Venue FromDataReader(SqlDataReader reader)
+        {
+            var item = new Venue();
+            item.VenueId = (int) reader["VenueId"];
+            item.ProviderId = (int)reader["ProviderId"];
+            item.ProviderOwnVenueRef = reader["ProviderOwnVenueRef"] as string;
+            item.VenueName = reader["VenueName"] as string;
+            item.Email = reader["Email"] as string;
+            item.Website = reader["Website"] as string;
+            item.Fax = reader["Fax"] as string;
+            item.Facilities = reader["Facilities"] as string;
+            item.RecordStatusId = (int) reader["RecordStatusId"];
+            item.CreatedByUserId = reader["CreatedByUserId"] as string;
+            item.CreatedDateTimeUtc = (DateTime)reader["CreatedDateTimeUtc"];
+            item.ModifiedByUserId = reader["ModifiedByUserId"] as string;
+            item.ModifiedDateTimeUtc = reader["ModifiedDateTimeUtc"] as DateTime?;
+            item.AddressId = (int)reader["AddressId"];
+            item.Telephone = reader["Telephone"] as string;
+            item.BulkUploadVenueId = reader["BulkUploadVenueId"] as string;
+            item.CosmosId = reader["CosmosId"] as string;
+            item.AddedByApplicationId = reader["AddedByApplicationId"] as int?;
+            item.UKPRN = (int) reader["UKPRN"];
+            item.Address = new Address()
+            {
+                Address1 = reader["AddressLine1"] as string,
+                Address2 = reader["AddressLine2"] as string,
+                County = reader["County"] as string,
+                Latitude = reader["Latitude"] as double?,
+                Longitude = reader["Longitude"] as double?,
+                Postcode = reader["Postcode"] as string,
+                Town = reader["Town"] as string
+            };
+
+            return item;
+        }
+    }
+}

--- a/src/Dfc.ProviderPortal.TribalExporter/Services/VenueCollectionService.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Services/VenueCollectionService.cs
@@ -88,20 +88,12 @@ namespace Dfc.ProviderPortal.TribalExporter.Services
             var uri = UriFactory.CreateDocumentCollectionUri(_cosmosDbSettings.DatabaseId, _cosmosDbCollectionSettings.VenuesCollectionId);
             var sql = $"SELECT* FROM c WHERE c.VENUE_ID = { venueId}";
             var options = new FeedOptions { EnableCrossPartitionQuery = true, MaxItemCount = -1 };
-
-            try
+            using (var client = _cosmosDbHelper.GetClient())
             {
+                var query =  client.CreateDocumentQuery<Venue>(uri, sql, options).AsDocumentQuery();
+                return (await query.ExecuteNextAsync()).FirstOrDefault();
+            };
 
-                using (var client = _cosmosDbHelper.GetClient())
-                {
-                    var query = client.CreateDocumentQuery<Venue>(uri, sql, options).ToList();
-                    return query.FirstOrDefault();
-                };
-            }
-            catch (Exception e)
-            {
-                return null;
-            }
         }
     }
 }

--- a/src/Dfc.ProviderPortal.TribalExporter/Services/VenueCollectionService.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Services/VenueCollectionService.cs
@@ -79,5 +79,24 @@ namespace Dfc.ProviderPortal.TribalExporter.Services
 
             return documents.Count() > 0;
         }
+
+        public async Task<bool> VenueExists(int venueId)
+        {
+            var documents = new List<Document>();
+
+            var uri = UriFactory.CreateDocumentCollectionUri(_cosmosDbSettings.DatabaseId, _cosmosDbCollectionSettings.VenuesCollectionId);
+            var sql = $"SELECT * FROM c WHERE c.VENUE_ID = {venueId}";
+                var options = new FeedOptions { EnableCrossPartitionQuery = true, MaxItemCount = -1 };
+
+            using (var client = _cosmosDbHelper.GetClient())
+            using (var query = client.CreateDocumentQuery(uri, sql, options).AsDocumentQuery())
+            {
+                while (query.HasMoreResults)
+                {
+                    foreach (var document in await query.ExecuteNextAsync<Document>()) documents.Add(document);
+                }
+            }
+            return documents.Count() > 0;
+        }
     }
 }

--- a/src/Dfc.ProviderPortal.TribalExporter/Services/VenueCollectionService.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Services/VenueCollectionService.cs
@@ -1,4 +1,5 @@
-﻿using Dfc.ProviderPortal.Packages;
+﻿using Dfc.CourseDirectory.Models.Models.Venues;
+using Dfc.ProviderPortal.Packages;
 using Dfc.ProviderPortal.TribalExporter.Interfaces;
 using Dfc.ProviderPortal.TribalExporter.Settings;
 using Microsoft.Azure.Documents;
@@ -80,23 +81,30 @@ namespace Dfc.ProviderPortal.TribalExporter.Services
             return documents.Count() > 0;
         }
 
-        public async Task<bool> VenueExists(int venueId)
+        public async Task<Venue> GetDocumentID(int venueId)
         {
             var documents = new List<Document>();
 
             var uri = UriFactory.CreateDocumentCollectionUri(_cosmosDbSettings.DatabaseId, _cosmosDbCollectionSettings.VenuesCollectionId);
-            var sql = $"SELECT * FROM c WHERE c.VENUE_ID = {venueId}";
-                var options = new FeedOptions { EnableCrossPartitionQuery = true, MaxItemCount = -1 };
+            var sql = $"SELECT* FROM c WHERE c.VENUE_ID = { venueId}";
+            var options = new FeedOptions { EnableCrossPartitionQuery = true, MaxItemCount = -1 };
 
-            using (var client = _cosmosDbHelper.GetClient())
-            using (var query = client.CreateDocumentQuery(uri, sql, options).AsDocumentQuery())
+            try
             {
-                while (query.HasMoreResults)
+
+                using (var client = _cosmosDbHelper.GetClient())
                 {
-                    foreach (var document in await query.ExecuteNextAsync<Document>()) documents.Add(document);
-                }
+                    var query = client.CreateDocumentQuery<Venue>(uri, sql, options).ToList();
+                    return query.FirstOrDefault();
+                };
             }
-            return documents.Count() > 0;
+            catch (Exception e)
+            {
+                return null;
+            }
         }
     }
 }
+
+
+

--- a/src/Dfc.ProviderPortal.TribalExporter/host.json
+++ b/src/Dfc.ProviderPortal.TribalExporter/host.json
@@ -1,4 +1,19 @@
 {
   "version": "2.0",
-  "functionTimeout": "12:00:00"
+  "functionTimeout": "12:00:00",
+  "extensions": {
+    "http": {
+      "routePrefix": "api",
+      "maxOutstandingRequests": 200,
+      "maxConcurrentRequests": 100,
+      "dynamicThrottlesEnabled": true,
+      "hsts": {
+        "isEnabled": true,
+        "maxAge": "10"
+      },
+      "customHeaders": {
+        "X-Content-Type-Options": "nosniff"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Added Functionality to Export Tribal Venues that are live into cosmos (status 2).

- If a tribal venue exists in cosmos, replace it.
- If a tribal venue does not exist insert it.
- Validate Venue against a whitelist of permitted UKPRN's. (Whitelist is stored in the root of storage container).
- Write results to storage container (failures & successes).
- Few changes to poco classes that are referenced in non-used projects.
