### PR TITLE
stop making record as pending if venue is not found.

### DIFF
--- a/src/Dfc.ProviderPortal.TribalExporter/Functions/ApprentishipMigrator.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Functions/ApprentishipMigrator.cs
@@ -430,8 +430,7 @@ namespace Dfc.ProviderPortal.TribalExporter.Functions
                                 status = cosmosVenueItem.Status;
                             else
                             {
-                                apprenticeshipErrors.Add($"LocationId: {location.LocationId} did not find a venue in cosmos, record marked as pending");
-                                status = VenueStatus.Pending;
+                                apprenticeshipWarning.Add($"LocationId: {location.LocationId} did not find a venue in cosmos, record marked as pending");
                             }
 
                             var appLocation = new ApprenticeshipLocationDTO()


### PR DESCRIPTION
- Stop marking record as PendingMigration when venue is not found. Add a warning message instead.