### PR TITLE
skip migrations that do not match venues.

### DIFF
--- a/src/Dfc.ProviderPortal.TribalExporter/Functions/ApprentishipMigrator.cs
+++ b/src/Dfc.ProviderPortal.TribalExporter/Functions/ApprentishipMigrator.cs
@@ -431,6 +431,7 @@ namespace Dfc.ProviderPortal.TribalExporter.Functions
                             else
                             {
                                 apprenticeshipWarning.Add($"LocationId: {location.LocationId} did not find a venue in cosmos, record marked as pending");
+                                continue;
                             }
 
                             var appLocation = new ApprenticeshipLocationDTO()


### PR DESCRIPTION
- Skip locations that do not match to venues when classroom based.