### PR TITLE
hotfix - make apprenticeship venueId nullable so that QAStatusMigrator can han…

### DIFF
--- a/src/Dfc.CourseDirectory.Models/Interfaces/Apprenticeships/IApprenticeshipLocation.cs
+++ b/src/Dfc.CourseDirectory.Models/Interfaces/Apprenticeships/IApprenticeshipLocation.cs
@@ -9,7 +9,7 @@ namespace Dfc.CourseDirectory.Models.Interfaces.Apprenticeships
     public interface IApprenticeshipLocation
     {
         Guid Id { get; set; } // Cosmos DB id
-        Guid VenueId { get; set; }
+        Guid? VenueId { get; set; }
         int? TribalId { get; set; }
         int ApprenticeshipLocationId { get; set; }
         Guid? LocationGuidId { get; set; }

--- a/src/Dfc.CourseDirectory.Models/Models/Apprenticeships/ApprenticeshipLocation.cs
+++ b/src/Dfc.CourseDirectory.Models/Models/Apprenticeships/ApprenticeshipLocation.cs
@@ -9,7 +9,7 @@ namespace Dfc.CourseDirectory.Models.Models.Apprenticeships
     public class ApprenticeshipLocation : IApprenticeshipLocation
     {
         public Guid Id { get; set; }
-        public Guid VenueId { get; set; }
+        public Guid? VenueId { get; set; }
         public int? TribalId { get; set; }
         public int ApprenticeshipLocationId { get; set; }
         public Guid? LocationGuidId { get; set; }


### PR DESCRIPTION
- change venueId to be nullable, so that apprenticeships created via qa does not break the QAStatusMigrator.